### PR TITLE
Fix hw keyboard number input for number fields

### DIFF
--- a/rootdir/system/usr/keychars/pm8xxx-keypad.kcm
+++ b/rootdir/system/usr/keychars/pm8xxx-keypad.kcm
@@ -223,10 +223,10 @@ key X {
 
 key Y {
     label:                              'Y'
-    number:                             '9'
+    number:                             '6'
     base:                               'y'
     shift, capslock:                    'Y'
-    alt:                                ','
+    alt:                                '6'
     shift+alt, capslock+alt:            '\u00a1'
 }
 

--- a/rootdir/system/usr/keychars/pm8xxx-keypad.kcm
+++ b/rootdir/system/usr/keychars/pm8xxx-keypad.kcm
@@ -1,5 +1,6 @@
 # Original idea by Paul-xxx
 # Made by KrSH - Danish version by hnl_dk
+# Number-entry bugfix by fred777
 # Xperia Mini Pro keyboard character map based on qwerty.kcm
 
 type ALPHA
@@ -132,7 +133,7 @@ key N {
 
 key O {
     label:                              'O'
-    number:                             '6'
+    number:                             '9'
     base:                               'o'
     shift, capslock:                    'O'
     alt:                                '9'
@@ -141,7 +142,7 @@ key O {
 
 key P {
     label:                              'P'
-    number:                             '7'
+    number:                             '0'
     base:                               'p'
     shift, capslock:                    'P'
     alt:                                '0'
@@ -150,7 +151,7 @@ key P {
 
 key Q {
     label:                              'Q'
-    number:                             '7'
+    number:                             '1'
     base:                               'q'
     shift, capslock:                    'Q'
     alt:                                '1'
@@ -159,7 +160,7 @@ key Q {
 
 key R {
     label:                              'R'
-    number:                             '7'
+    number:                             '4'
     base:                               'r'
     shift, capslock:                    'R'
     alt:                                '4'
@@ -171,13 +172,13 @@ key S {
     number:                             '7'
     base:                               's'
     shift, capslock:                    'S'
-    alt:                                ':'
+    alt:                                '.'
     shift+alt, capslock+alt:            '\u00df'
 }
 
 key T {
     label:                              'T'
-    number:                             '8'
+    number:                             '5'
     base:                               't'
     shift, capslock:                    'T'
     alt:                                '5'
@@ -186,7 +187,7 @@ key T {
 
 key U {
     label:                              'U'
-    number:                             '8'
+    number:                             '7'
     base:                               'u'
     shift, capslock:                    'U'
     alt:                                '7'
@@ -204,7 +205,7 @@ key V {
 
 key W {
     label:                              'W'
-    number:                             '9'
+    number:                             '2'
     base:                               'w'
     shift, capslock:                    'W'
     alt:                                '2'
@@ -225,16 +226,16 @@ key Y {
     number:                             '9'
     base:                               'y'
     shift, capslock:                    'Y'
-    alt:                                '6'
+    alt:                                ','
     shift+alt, capslock+alt:            '\u00a1'
 }
 
 key Z {
     label:                              'Z'
-    number:                             '9'
+    number:                             '6'
     base:                               'z'
     shift, capslock:                    'Z'
-    alt:                                'z'
+    alt:                                '6'
     shift+alt, capslock+alt:            none
 }
 


### PR DESCRIPTION
Fix hw keyboard number input for number fields, e.g. for phone numbers in Contacts app. Applicable for both - QWERTY and QWERTZ layout.
